### PR TITLE
typo fixes (get_smart_output => _get_smart_output)

### DIFF
--- a/lib/Disk/SMART.pm
+++ b/lib/Disk/SMART.pm
@@ -207,7 +207,7 @@ sub run_short_test {
     my ( $self, $device ) = @_;
     $self->_validate_param($device);
 
-    my $test_out = get_smart_output( $device, '-t short' );
+    my $test_out = _get_smart_output( $device, '-t short' );
     my ($short_test_time) = $test_out =~ /Please wait (.*) minutes/s;
     sleep( $short_test_time * 60 );
 


### PR DESCRIPTION
typo fixes (get_smart_output => _get_smart_output)

fix "Undefined subroutine &Disk::SMART::get_smart_output called at /usr/local/share/perl/5.20.2/Disk/SMART.pm line 210" error
when run
run_short_test(DEVICE)